### PR TITLE
Change canadv.ash -> can_adventure due to barrel

### DIFF
--- a/kolmafia/dependencies.txt
+++ b/kolmafia/dependencies.txt
@@ -1,5 +1,4 @@
 https://github.com/c2talon/c2t_lib/branches/master/kolmafia/
 https://github.com/c2talon/c2t_kol_scripts/branches/master/kolmafia/
-https://svn.code.sf.net/p/therazekolmafia/canadv/code/
 https://github.com/Ezandora/Bastille/branches/Release/
 https://github.com/Ezandora/Briefcase/branches/Release/

--- a/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
+++ b/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
@@ -11,7 +11,6 @@ import <c2t_hccs_preAdv.ash>
 import <c2t_cartographyHunt.ash>
 import <c2t_lib.ash>
 import <c2t_cast.ash>
-import <canadv.ash>
 
 int START_TIME = now_to_int();
 
@@ -1736,7 +1735,7 @@ void c2t_hccs_fights() {
 				visit_url('shop.php?whichshop=meatsmith&action=talk');
 				run_choice(1);
 			}
-			if (!can_adv($location[the skeleton store],false))
+			if (!cli_execute('can_adventure the skeleton store'))
 				abort('Cannot open skeleton store!');
 			if ($location[the skeleton store].turns_spent == 0 && !$location[the skeleton store].noncombat_queue.contains_text('Skeletons In Store'))
 				adv1($location[the skeleton store],-1,'');


### PR DESCRIPTION
Due to the newest Mafia removing the barrel as location, canadv.ash throws an error.
To no longer rely on canadv.ash (and it should be replaced with can_adventure.ash) -> change

I couldn't get location_available(loc) to work, idk. So for now it's a cli_execute. I am sure there are more elegant ways.
Script starts, but haven't yet seen if it runs through - though it shouldn't influence much I hope.