### PR TITLE
No chorale perm edge case catch

### DIFF
--- a/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
+++ b/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
@@ -1236,7 +1236,7 @@ boolean c2t_hccs_preFamiliar() {
 	c2t_hccs_getEffect($effect[empathy]);
 
 	//AT-only buff
-	if (my_class() == $class[accordion thief])
+	if (my_class() == $class[accordion thief] && have_skill($skill[chorale of companionship]))
 		ensure_song($effect[chorale of companionship]);
 
 	//find highest familar weight


### PR DESCRIPTION
Tested on personal branch (which does not have chorale of companionship permed)

Prevent trying to effect chorale if not owned. Currently script bricks and does not continue