### PR TITLE
Prevent failure on elron's explosive etude

### DIFF
--- a/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
+++ b/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
@@ -1553,7 +1553,7 @@ boolean c2t_hccs_preSpell() {
 	retrieve_item(nuts<0?0:nuts,$item[obsidian nutcracker]);
 
 	//AT-only buff
-	if (my_class() == $class[accordion thief])
+	if (my_class() == $class[accordion thief] && have_skill($skill[elron's explosive etude]))
 		ensure_song($effect[elron's explosive etude]);
 
 	// cargo pocket


### PR DESCRIPTION
Tested on personal branch (which does not have Elron's Explosive etude permed)

Prevent trying to effect elron's explosive etude if not owned. Currently script bricks and does not continue