### PR TITLE
Boombox in weapon test saves 0.6 turns

### DIFF
--- a/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
+++ b/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
@@ -1370,6 +1370,10 @@ boolean c2t_hccs_preWeapon() {
 	//pizza cube prep since making this takes a turn without free crafts
 	if (c2t_hccs_pizzaCube() && c2t_hccs_freeCraftsLeft() == 0)
 		retrieve_item(1,$item[ointment of the occult]);
+	
+	//boombox weapon damage passive
+	if (item_amount($item[songboom&trade; boombox]) > 0 && get_property('boomBoxSong') != "These Fists Were Made for Punchin'")
+		cli_execute('boombox damage');
 
 	//cast triple size
 	if (available_amount($item[powerful glove]) > 0 && have_effect($effect[triple-sized]) == 0 && !c2t_cast($skill[cheat code: triple size]))


### PR DESCRIPTION
Tested in mafia CLI with ashq.

Can see it correctly changes to weapon damage when meat song is on. Does not do anything if weapon damage is already on

> ashq if (item_amount($item[songboom™ boombox]) > 0 && get_property('boomBoxSong') != "These Fists Were Made for Punchin'") cli_execute('boombox damage');

Preference choiceAdventure1312 changed from 0 to 4
Using 1 SongBoom™ BoomBox...
Preference lastEncounter changed from horrible tourist family to Choose a Soundtrack
Encounter: Choose a Soundtrack
Preference boomBoxSong changed from Total Eclipse of Your Meat to
Preference boomBoxSong changed from to Total Eclipse of Your Meat
Preference boomBoxSong changed from Total Eclipse of Your Meat to These Fists Were Made for Punchin'
Preference _boomBoxSongsLeft changed from 8 to 7
Setting soundtrack to These Fists Were Made for Punchin'
Preference _concoctionDatabaseRefreshes changed from 874 to 875
Finished using 1 SongBoom™ BoomBox.
Preference choiceAdventure1312 changed from 4 to 0

> ashq if (item_amount($item[songboom™ boombox]) > 0 && get_property('boomBoxSong') != "These Fists Were Made for Punchin'") cli_execute('boombox damage');

> boombox meat

Preference choiceAdventure1312 changed from 0 to 5
Using 1 SongBoom™ BoomBox...
Encounter: Choose a Soundtrack
Preference boomBoxSong changed from These Fists Were Made for Punchin' to
Preference boomBoxSong changed from to These Fists Were Made for Punchin'
Preference boomBoxSong changed from These Fists Were Made for Punchin' to Total Eclipse of Your Meat
Preference _boomBoxSongsLeft changed from 7 to 6
Setting soundtrack to Total Eclipse of Your Meat
Preference _concoctionDatabaseRefreshes changed from 875 to 876
Finished using 1 SongBoom™ BoomBox.
Preference choiceAdventure1312 changed from 5 to 0

> ashq if (item_amount($item[songboom™ boombox]) > 0 && get_property('boomBoxSong') != "These Fists Were Made for Punchin'") cli_execute('boombox damage');

Preference choiceAdventure1312 changed from 0 to 4
Using 1 SongBoom™ BoomBox...
Encounter: Choose a Soundtrack
Preference boomBoxSong changed from Total Eclipse of Your Meat to
Preference boomBoxSong changed from to Total Eclipse of Your Meat
Preference boomBoxSong changed from Total Eclipse of Your Meat to These Fists Were Made for Punchin'
Preference _boomBoxSongsLeft changed from 6 to 5
Setting soundtrack to These Fists Were Made for Punchin'
Preference _concoctionDatabaseRefreshes changed from 876 to 877
Finished using 1 SongBoom™ BoomBox.
Preference choiceAdventure1312 changed from 4 to 0