### PR TITLE
Make the telescope high-look re-entrant

### DIFF
--- a/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
+++ b/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
@@ -985,8 +985,8 @@ boolean c2t_hccs_allTheBuffs() {
 	c2t_hccs_levelingFamiliar(true);
 
 	//telescope
-	if (get_property("telescopeUpgrades").to_int() > 0 && get_property("telescopeLookedHigh").to_boolean() != true)
-		cli_execute('telescope high');
+	if (!get_property("telescopeLookedHigh").to_boolean())
+		cli_execute('try;telescope high');
 
 	cli_execute('mcd 10');
 

--- a/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
+++ b/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
@@ -985,7 +985,7 @@ boolean c2t_hccs_allTheBuffs() {
 	c2t_hccs_levelingFamiliar(true);
 
 	//telescope
-	if (get_property("telescopeUpgrades").to_int() > 0)
+	if (get_property("telescopeUpgrades").to_int() > 0 && get_property("telescopeLookedHigh").to_boolean() != true)
 		cli_execute('telescope high');
 
 	cli_execute('mcd 10');


### PR DESCRIPTION
"telescope high" throws if you have already looked high. We need to check if this daily flag has been used today to be re-entrant for the leveling checks