### PR TITLE
Update c2t_hccs.ash to add Comma Chameleon support

### DIFF
--- a/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
+++ b/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
@@ -854,7 +854,10 @@ boolean c2t_hccs_levelup() {
 	//also attempt to pull stick-knife in weapon and spell tests since having 150 offstat is possible then
 	if (my_primestat() == $stat[muscle])
 		c2t_hccs_pull($item[stick-knife of loathing]);//150 mus; saves 4 for spell test
-	if (have_familiar($familiar[mini-trainbot]))
+	//chameleon NEW CODE
+	if (have_familiar($familiar[comma chameleon]))
+		c2t_hccs_pull($item[homemade robot gear]);//should save at least 15 turns? END NEW CODE
+	else if (have_familiar($familiar[mini-trainbot]))
 		c2t_hccs_pull($item[overloaded yule battery]);//should save at least 2 turns at worst, 4-ish at best
 	//familiar pants
 	if (!c2t_hccs_pull($item[repaid diaper]))
@@ -1355,7 +1358,16 @@ boolean c2t_hccs_preFamiliar() {
 	//find highest familar weight
 	//TODO take familiar equipment or more optimal combinations into account
 	familiar highest = $familiar[none];
-	if (have_familiar($familiar[mini-trainbot])
+	//comma chameleon NEW CODE
+	if (have_familiar($familiar[comma chameleon])
+		&& have_familiar($familiar[homemade robot]))
+	{
+		use_familiar($familiar[comma chameleon]);
+		visit_url('inv_equip.php?pwd&action=equip&whichitem=6102');
+		highest = $familiar[comma chameleon];
+	}
+	//comma chameleon END NEW CODE
+	else if (have_familiar($familiar[mini-trainbot])
 		&& available_amount($item[overloaded yule battery]) == 0
 		&& c2t_hccs_tomeClipArt($item[box of familiar jacks]))
 	{

--- a/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
+++ b/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
@@ -854,11 +854,8 @@ boolean c2t_hccs_levelup() {
 	//also attempt to pull stick-knife in weapon and spell tests since having 150 offstat is possible then
 	if (my_primestat() == $stat[muscle])
 		c2t_hccs_pull($item[stick-knife of loathing]);//150 mus; saves 4 for spell test
-	//chameleon NEW CODE
-	if (have_familiar($familiar[comma chameleon]))
-		c2t_hccs_pull($item[homemade robot gear]);//should save at least 15 turns? END NEW CODE
-	else if (have_familiar($familiar[mini-trainbot]))
-		c2t_hccs_pull($item[overloaded yule battery]);//should save at least 2 turns at worst, 4-ish at best
+	//no mini trainbot pull
+
 	//familiar pants
 	if (!c2t_hccs_pull($item[repaid diaper]))
 		c2t_hccs_pull($item[great wolf's beastly trousers]);//100 mus; saves 2 for fam test
@@ -977,9 +974,7 @@ boolean c2t_hccs_allTheBuffs() {
 			c2t_hccs_printWarn("Failed to synthesize stat buff");
 	}
 
-	//third tome use //no longer using bee's knees for stat boost on non-moxie, but still need same strength buff?
-	if (have_effect($effect[purity of spirit]) == 0 && c2t_hccs_tomeClipArt($item[cold-filtered water]))
-		use(1,$item[cold-filtered water]);
+	//no cold philtered water, third summon is for homemade robot fam equip
 
 	//rhinestones to help moxie leveling
 	if (my_primestat() == $stat[moxie])

--- a/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
+++ b/kolmafia/scripts/c2t_hccs/c2t_hccs.ash
@@ -1357,17 +1357,16 @@ boolean c2t_hccs_preFamiliar() {
 
 	//find highest familar weight
 	//TODO take familiar equipment or more optimal combinations into account
-	familiar highest = $familiar[none];
-	//comma chameleon NEW CODE
-	if (have_familiar($familiar[comma chameleon])
-		&& have_familiar($familiar[homemade robot]))
-	{
-		use_familiar($familiar[comma chameleon]);
-		visit_url('inv_equip.php?pwd&action=equip&whichitem=6102');
-		highest = $familiar[comma chameleon];
-	}
-	//comma chameleon END NEW CODE
-	else if (have_familiar($familiar[mini-trainbot])
+	//comma cham NEW CODE blatantly stolen from Prusias
+	familiar highest = $familiar[none];cli_execute("refresh familiar");
+	if (have_familiar($familiar[Comma Chameleon]) && have_familiar($familiar[homemade robot]) && c2t_hccs_tomeClipArt($item[box of familiar jacks]) && (get_property("homemadeRobotUpgrades").to_int() >= 9)) {
+		use_familiar($familiar[homemade robot]);
+		use(1,$item[box of familiar jacks]);
+		use_familiar($familiar[Comma chameleon]);
+		cli_execute("/equip familiar homemade robot gear");
+		cli_execute("refresh familiar");
+		highest = $familiar[Comma Chameleon];
+	} else if (have_familiar($familiar[mini-trainbot])
 		&& available_amount($item[overloaded yule battery]) == 0
 		&& c2t_hccs_tomeClipArt($item[box of familiar jacks]))
 	{


### PR DESCRIPTION
I've tried to add Comma chameleon support for the familiar test, i edited the homemade robot equip pull instead of the mini-trainbot fam equip, and then a check if you have comma chameleon + homemade robot (you are supposed to have the robot maxed out, i don't know how to check it since kolmafia does not track it at all, if you check the following excerpt from my last test session the chameleon is 62 lbs while it should have been 120+, given the fact that the service was 39 turns calculated but 20 turns in reality)

Session + modtrace

> Checking test 5: Breed More Collies

familiar Hovering Sombrero (31 lbs)
> Running pre-Breed More Collies stuff...

equip weapon Fourth of May Cosplay Saber

cast 1 Cannelloni Cocoon
You gain 1,000 hit points

cast 1 Cannelloni Cocoon
You gain 1,000 hit points

use 1 photocopied monster
Preference photocopyMonster changed from ungulith to 
Preference _photocopyUsed changed from false to true
Preference lastAdventure changed from The Dire Warren to None

[66] photocopied monster
Preference lastEncounter changed from Configure Your Unbreakable Umbrella to ungulith
Encounter: ungulith
Round 0: Just Eyes wins initiative!
Preference cosmicBowlingBallReturnCombats changed from 8 to 7
Preference _concoctionDatabaseRefreshes changed from 407 to 408
> c2t_bb macro: pickpocket;if hasskill 7291;skill 7291;endif;
Round 1: Just Eyes executes a macro!
Round 1: Just Eyes casts METEOR SHOWER!
You acquire an effect: Meteor Showered (1)
Round 2: You lose 32 hit points
Preference _meteorShowerUses changed from 0 to 1
> c2t_bb macro: if hasskill 7311;skill 7311;endif;
Round 2: Just Eyes executes a macro!
Preference lastEncounter changed from ungulith to Using the Force
Encounter: Using the Force
Took choice 1387/3: &quot;You will drop your things and walk away.&quot;
choice.php?whichchoice=1387&option=3&pwd
Preference _saberForceUses changed from 0 to 1
You acquire an item: corrupted marrow
You acquire an effect: Billiards Belligerence (10)
Preference _poolGames changed from 0 to 1
Preference lastAdventure changed from None to The Dire Warren

cast 1 Empathy of the Newt
You acquire an effect: Empathy (5)

familiar Comma Chameleon (62 lbs)

equip familiar homemade robot gear
Maximizer: familiar weight

equip hat Daylight Shavings Helmet

equip weapon fish hatchet
Preference _concoctionDatabaseRefreshes changed from 408 to 409

equip off-hand Fourth of May Cosplay Saber
Preference _concoctionDatabaseRefreshes changed from 409 to 410

equip back unwrapped knock-off retro superhero cape
Preference _concoctionDatabaseRefreshes changed from 410 to 411

equip shirt Jurassic Parka
Preference _concoctionDatabaseRefreshes changed from 411 to 412

equip pants Great Wolf's beastly trousers
Preference _concoctionDatabaseRefreshes changed from 412 to 413

equip acc1 Brutal brogues
Preference _concoctionDatabaseRefreshes changed from 413 to 414

equip acc2 hewn moon-rune spoon
Preference _concoctionDatabaseRefreshes changed from 414 to 415

equip acc3 Beach Comb
Preference _concoctionDatabaseRefreshes changed from 415 to 416
> <table border=2><tr><td>type</td><td>source</td><td colspan=2>Familiar Weight</td><td colspan=2>Familiar Weight Percent</td><td colspan=2>Hidden Familiar Weight</td><td colspan=2>Familiar Weight Cap</td></tr><tr><td>Item</td><td>Daylight Shavings Helmet</td><td>+5.00</td><td>=&nbsp;+5.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>Item</td><td>fish hatchet</td><td>+5.00</td><td>=&nbsp;+10.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>Item</td><td>Fourth of May Cosplay Saber</td><td>+10.00</td><td>=&nbsp;+20.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>Item</td><td>Great Wolf's beastly trousers</td><td>+10.00</td><td>=&nbsp;+30.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>Item</td><td>Brutal brogues</td><td>+8.00</td><td>=&nbsp;+38.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>Item</td><td>hewn moon-rune spoon</td><td>+5.00</td><td>=&nbsp;+43.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>Item</td><td>Beach Comb</td><td>+5.00</td><td>=&nbsp;+48.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>Skill</td><td>Crimbo Training: Concierge</td><td>+1.00</td><td>=&nbsp;+49.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>Skill</td><td>Amphibian Sympathy</td><td>+5.00</td><td>=&nbsp;+54.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>Effect</td><td>Meteor Showered</td><td>+20.00</td><td>=&nbsp;+74.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>Effect</td><td>Blood Bond</td><td>+5.00</td><td>=&nbsp;+79.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>Effect</td><td>Empathy</td><td>+5.00</td><td>=&nbsp;+84.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>Effect</td><td>Leash of Linguini</td><td>+5.00</td><td>=&nbsp;+89.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>Effect</td><td>Billiards Belligerence</td><td>+5.00</td><td>=&nbsp;+94.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>Effect</td><td>Do I Know You From Somewhere?</td><td>+5.00</td><td>=&nbsp;+99.00</td><td></td><td></td><td></td><td></td><td></td><td></td></tr></table><br>
> Test 5: Breed More Collies (familiar) is at or below the threshold at 39 turns. Running the task...
> Checking test 5...
Preference _concoctionDatabaseRefreshes changed from 416 to 417
Took choice 1089/5: Perform Service (20 Adventures)
choice.php?pwd&whichchoice=1089&option=5
You lose 20 Adventures
You acquire an item: squeaky toy rose
Preference csServicesPerformed changed from Coil Wire,Feed Conspirators,Build Playground Mazes,Feed The Children,Donate Blood,Make Margaritas to Coil Wire,Feed Conspirators,Build Playground Mazes,Feed The Children,Donate Blood,Make Margaritas,Breed More Collies
Preference _concoctionDatabaseRefreshes changed from 417 to 418
> Checking test 5...
Preference _c2t_hccs_testData changed from mox,4,1,-4;mys,3,1,-6;mus,2,1,-93;HP,1,1,-67;item,9,1,-3 to mox,4,1,-4;mys,3,1,-6;mus,2,1,-93;HP,1,1,-67;item,9,1,-3;familiar,5,20,39
> c2t_hccs has taken 8 minutes 1.547 seconds to execute so far.
> Checking test 10: Clean Steam Tunnels
> Running wanderer fight
